### PR TITLE
Add "headers" option and some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ const Monitor = new WebMonitor("https://website-example.com", options);
 
 Object
 
-| PARAMETER | TYPE   | OPTIONAL | DEFAULT | DESCRIPTION                                    |
-| --------- | ------ | -------- | ------- | ---------------------------------------------- |
-| interval  | number | ✓        | 3000ms  | Interval for check site                        |
-| retries   | number | ✓        | 3       | Retries before create an outage                |
-| timeout   | number | ✓        | 3000ms  | Maximum waiting time before creating an outage |
+| PARAMETER | TYPE                                   | OPTIONAL | DEFAULT   | DESCRIPTION                                    |
+| --------- | -------------------------------------- | -------- | --------- | ---------------------------------------------- |
+| interval  | number                                 | ✓        | 3000ms    | Interval for check site                        |
+| retries   | number                                 | ✓        | 3         | Retries before create an outage                |
+| timeout   | number                                 | ✓        | 3000ms    | Maximum waiting time before creating an outage |
+| headers   | { [key: string]: string } \| undefined | ✓        | undefined | Additional headers to be attached to requests  |
 
 ## Events
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ interface Iconfig {
 		interval: number
 		retries: number
 		timeout: number
+		headers: { [key: string]: string } | undefined
 		available: null
 		uptime: null
 		ping: null
@@ -18,6 +19,7 @@ export const config: Iconfig = {
 		interval: 3000,
 		retries: 3,
 		timeout: 3000,
+		headers: undefined,
 		available: null,
 		uptime: null,
 		ping: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export class WebMonitor extends EventEmitter {
 	public interval: number = config.default.interval;
 	public retries: number = config.default.retries;
 	public timeout: number = config.default.timeout
+	public headers: ({ [key: string]: string } | undefined) = config.default.headers;
 	public available: (boolean | null) = config.default.available;
 	public uptime: (number | null) = config.default.uptime;
 	public ping: (number | null) = config.default.ping;
@@ -37,6 +38,10 @@ export class WebMonitor extends EventEmitter {
 				if (typeof options.timeout !== 'number') throw new TypeError('INVALID_OPTION timeout option must be a number')
 				this.timeout = options.timeout
 			}
+			if (options.headers) {
+				if (typeof options.headers !== 'object') throw new TypeError('INVALID_OPTION headers option must be an object')
+				this.headers = options.headers
+			}
 		}
 	}
 	private fetchURL() {
@@ -47,7 +52,7 @@ export class WebMonitor extends EventEmitter {
 			}, this.timeout)
 		})
 		const fetchFunction = new Promise((resolve, reject) => {
-			fetch(this.url)
+			fetch(this.url, { headers: this.headers })
 				.then(res => {
 					resolve({
 						statusCode: res.status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export class WebMonitor extends EventEmitter {
 		const outage: IOutage = {
 			type: 'outage',
 			statusCode: statusCode || undefined,
-			statusTexte: statusText || undefined,
+			statusText: statusText || undefined,
 			url: this.url,
 			ping: this.ping,
 			unavailability: this.unavailability
@@ -113,7 +113,7 @@ export class WebMonitor extends EventEmitter {
 		const up: IUp = {
 			type: 'up',
 			statusCode: statusCode || undefined,
-			statusTexte: statusText || undefined,
+			statusText: statusText || undefined,
 			url: this.url,
 			ping: this.ping,
 			uptime: this.uptime

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,6 +1,6 @@
 import { WebMonitor } from '../index';
 
-const Monitor = new WebMonitor("https://api.french-gaming-family.com", {
+const Monitor = new WebMonitor("https://google.com", {
 	interval: 3000,
 	timeout: 5000,
 	headers: { 'Cache-Control': 'no-cache' }

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -2,7 +2,8 @@ import { WebMonitor } from '../index';
 
 const Monitor = new WebMonitor("https://api.french-gaming-family.com", {
 	interval: 3000,
-	timeout: 5000
+	timeout: 5000,
+	headers: { 'Cache-Control': 'no-cache' }
 })
 
 Monitor.start()

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface IOptions {
 	interval?: number | string;
 	retries?: number;
 	timeout?: number;
+	headers?: { [key: string]: string } | undefined;
 }
 
 export interface IOutage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface IOptions {
 export interface IOutage {
 	type: string
 	statusCode: (number | undefined),
-	statusTexte: (string | undefined),
+	statusText: (string | undefined),
 	ping: number | null
 	url: string
 	unavailability: number
@@ -21,7 +21,7 @@ export interface IOutage {
 export interface IUp {
 	type: string
 	statusCode: (number | undefined),
-	statusTexte: (string | undefined),
+	statusText: (string | undefined),
 	ping: number | null
 	url: string
 	uptime: number | null


### PR DESCRIPTION
This PR adds a "headers" option for outgoing requests. This will allow the client to add any headers that may be required to receive the desired response from the server.

Additionally, two minor fixes:
* Changes the test URL to google.com, as api.french-gaming-family.com returns a 404.
* Fixes typo "statusTexte".

To do: One improvement would be to accept the fetch API's [`Headers` object](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#headers), as well as key/value pairs.