### PR TITLE
Add `catchAllErrors` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ const Monitor = new WebMonitor("https://website-example.com", options);
 
 Object
 
-| PARAMETER | TYPE                                   | OPTIONAL | DEFAULT   | DESCRIPTION                                    |
-| --------- | -------------------------------------- | -------- | --------- | ---------------------------------------------- |
-| interval  | number                                 | ✓        | 3000ms    | Interval for check site                        |
-| retries   | number                                 | ✓        | 3         | Retries before create an outage                |
-| timeout   | number                                 | ✓        | 3000ms    | Maximum waiting time before creating an outage |
-| headers   | { [key: string]: string } \| undefined | ✓        | undefined | Additional headers to be attached to requests  |
+| PARAMETER      | TYPE                        | OPTIONAL  | DEFAULT | DESCRIPTION                                                             |
+|----------------|-----------------------------|-----------|---------|-------------------------------------------------------------------------|
+| interval       | number                      | ✓         | 3000ms  | Interval for check site                                                 |
+| retries        | number                      | ✓         | 3       | Retries before create an outage                                         |
+| timeout        | number                      | ✓         | 3000ms  | Maximum waiting time before creating an outage                          |
+| headers        | { [key: string]: string } \ | undefined | ✓       | Additional headers to be attached to requests                           |
+| catchAllErrors | boolean                     | ✓         | false   | When enabled, all errors will count towards outages, not just timeouts. |
 
 ## Events
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ interface Iconfig {
 		retries: number
 		timeout: number
 		headers: { [key: string]: string } | undefined
+		catchAllErrors: boolean
 		available: null
 		uptime: null
 		ping: null
@@ -20,6 +21,7 @@ export const config: Iconfig = {
 		retries: 3,
 		timeout: 3000,
 		headers: undefined,
+		catchAllErrors: false,
 		available: null,
 		uptime: null,
 		ping: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface IOptions {
 	retries?: number;
 	timeout?: number;
 	headers?: { [key: string]: string } | undefined;
+	catchAllErrors?: boolean;
 }
 
 export interface IOutage {


### PR DESCRIPTION
I have a use-case where the pinger will be awaiting the network coming up. During this time, it might receive errors other than a timeout, e.g. `ERR_INTERNET_DISCONNECTED`. I need these to be treated as a failure, and count towards an outage, instead of just being emitted as an error. 

This commit adds the `catchAllErrors` options. When enabled, all errors will count towards outages, not just timeouts. It is disabled by default, and the usual behaviour applies.